### PR TITLE
Tesseract has moved from google code to github

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ case $csi_deploy_type in
 
         echo "Installing Tesseract OCR..."
         port install tesseract
-        cd /opt/local/share/tessdata && wget https://tesseract-ocr.googlecode.com/files/eng.traineddata.gz && gunzip eng.traineddata.gz && cd -
+        cd /opt/local/share/tessdata && wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata && cd -
         ;;
       "Linux")
         apt-get --version > /dev/null 2>&1

--- a/vagrant/install/tesseract.sh
+++ b/vagrant/install/tesseract.sh
@@ -1,3 +1,3 @@
 #!/bin/bash --login
 printf "Installing Tesseract OCR **************************************************************"
-sudo /bin/bash --login -c "apt-get install -y tesseract-ocr-all && cd /usr/share/tesseract-ocr && wget https://tesseract-ocr.googlecode.com/files/eng.traineddata.gz && gunzip eng.traineddata.gz && cd -"
+sudo /bin/bash --login -c "apt-get install -y tesseract-ocr-all && cd /usr/share/tesseract-ocr && wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata && cd -"


### PR DESCRIPTION
https://github.com/tesseract-ocr/tesseract/wiki#linux says to use https://github.com/tesseract-ocr/tessdata as the trained data repo. Github doesn't seem to want to allow gzip downloads (probably just supports transport-encoding), so the `gunzip` step is now unnecessary.