### PR TITLE
Add ansible roles, playbook, and inventory files

### DIFF
--- a/packer/ansible/inventory
+++ b/packer/ansible/inventory
@@ -1,0 +1,3 @@
+localhost:
+  hosts:
+    localhost	ansible_connection=local

--- a/packer/ansible/playbook.yaml
+++ b/packer/ansible/playbook.yaml
@@ -1,0 +1,48 @@
+---
+
+- hosts: localhost
+  connection: local
+  become: yes
+  gather_facts: yes
+  tasks:
+    - script: /tmp/provisioner-ansible/roles/aliases/files/aliases.rb
+    - script: /tmp/provisioner-ansible/roles/rvm/files/rvm.sh
+    - script: /tmp/provisioner-ansible/roles/bashrc/files/bashrc.sh
+    - script: /tmp/provisioner-ansible/roles/ruby/files/ruby.sh
+    - script: /tmp/provisioner-ansible/roles/csi/files/csi.sh
+    - script: /tmp/provisioner-ansible/roles/beef/files/beef.rb
+    - script: /tmp/provisioner-ansible/roles/burpsuite/files/burpsuite.sh
+    - script: /tmp/provisioner-ansible/roles/jenkins/files/jenkins.sh
+    - script: /tmp/provisioner-ansible/roles/android/files/android.sh
+    - script: /tmp/provisioner-ansible/roles/sox/files/sox.sh
+    - script: /tmp/provisioner-ansible/roles/baresip/files/baresip.sh
+    - script: /tmp/provisioner-ansible/roles/phantomjs_wrapper/files/phantomjs_wrapper.sh
+    - script: /tmp/provisioner-ansible/roles/geckodriver/files/geckodriver.sh
+    - script: /tmp/provisioner-ansible/roles/chrome/files/chrome.sh
+    - script: /tmp/provisioner-ansible/roles/ansible/files/ansible.sh
+    - script: /tmp/provisioner-ansible/roles/openvas/files/openvas.sh
+    - script: /tmp/provisioner-ansible/roles/openvas_wrappers/files/openvas_wrappers.sh
+    - script: /tmp/provisioner-ansible/roles/metasploit/files/metasploit.rb
+    - script: /tmp/provisioner-ansible/roles/wpscan/files/wpscan.rb
+    - script: /tmp/provisioner-ansible/roles/ssllabs-scan/files/ssllabs-scan.sh
+    - script: /tmp/provisioner-ansible/roles/sublist3r/files/sublist3r.sh
+    - script: /tmp/provisioner-ansible/roles/scapy/files/scapy.sh
+    - script: /tmp/provisioner-ansible/roles/terminator/files/terminator.sh
+    - script: /tmp/provisioner-ansible/roles/apache2/files/apache2.sh
+    - script: /tmp/provisioner-ansible/roles/tor/files/tor.sh
+    - script: /tmp/provisioner-ansible/roles/toggle_tor/files/toggle_tor.sh
+    - script: /tmp/provisioner-ansible/roles/nmap_all_live_hosts/files/nmap_all_live_hosts.sh
+    - script: /tmp/provisioner-ansible/roles/arachni/files/arachni.sh
+    - script: /tmp/provisioner-ansible/roles/eyewitness/files/eyewitness.sh
+    - script: /tmp/provisioner-ansible/roles/afl/files/afl.sh
+    - script: /tmp/provisioner-ansible/roles/peda/files/peda.sh
+    - script: /tmp/provisioner-ansible/roles/pwntools/files/pwntools.sh
+    - script: /tmp/provisioner-ansible/roles/scout2/files/scout2.sh
+    - script: /tmp/provisioner-ansible/roles/strace/files/strace.sh
+    - script: /tmp/provisioner-ansible/roles/openvpn/files/openvpn.sh
+    - script: /tmp/provisioner-ansible/roles/fuzzdb/files/fuzzdb.sh
+    - script: /tmp/provisioner-ansible/roles/rc.local/files/rc.local.sh
+    - script: /tmp/provisioner-ansible/roles/vim/files/vim.sh
+    - script: /tmp/provisioner-ansible/roles/firefox/files/firefox.sh
+    - script: /tmp/provisioner-ansible/roles/docker/files/docker.sh
+    - script: /tmp/provisioner-ansible/roles/kali_customize/files/kali_customize.rb

--- a/packer/ansible/roles/afl/files/afl.sh
+++ b/packer/ansible/roles/afl/files/afl.sh
@@ -1,0 +1,9 @@
+#!/bin/bash --login
+# Build from source in order to support Qemu Instrumentation:
+# Found in https://github.com/mirrorer/afl/README.md => "4) Instrumenting binary-only apps"
+sudo apt install -y libtool libtool-bin libglib2.0-dev
+sudo /bin/bash --login -c 'cd /opt && git clone https://github.com/mirrorer/afl afl-dev && cd /opt/afl-dev && make && cd /opt/afl-dev/qemu_mode && ./build_qemu_support.sh'
+
+ls -l /opt/afl-dev | grep '^-rwx' | awk '{print $9}' | while read afl_bin; do 
+  sudo ln -s /opt/afl-dev/$afl_bin /usr/local/bin/
+done

--- a/packer/ansible/roles/afl/meta/main.yml
+++ b/packer/ansible/roles/afl/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: eyewitness }

--- a/packer/ansible/roles/afl/tasks/main.yml
+++ b/packer/ansible/roles/afl/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: afl.sh

--- a/packer/ansible/roles/aliases/files/aliases.rb
+++ b/packer/ansible/roles/aliases/files/aliases.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+alias_file = '/etc/profile.d/aliases.sh'
+system("sudo touch #{alias_file}")
+system("sudo chmod 777 #{alias_file}")
+File.open(alias_file, 'w') do |f|
+  f.puts '#!/bin/bash'
+  f.puts "alias kpid='kill -15'"
+  f.puts "alias prep='ps -ef | grep'"
+  f.puts "alias sup='sudo su -'"
+  f.puts "alias vi='vim -i NONE'"
+  f.puts "alias vim='vim -i NONE'"
+end
+system("sudo chmod 755 #{alias_file}")

--- a/packer/ansible/roles/aliases/tasks/main.yml
+++ b/packer/ansible/roles/aliases/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: wait for reboot
+  local_action: wait_for_host={{ ansible_ssh_host | default(inventory_hostname) }} state=started timeout=300
+- script: aliases.rb

--- a/packer/ansible/roles/android/files/android.sh
+++ b/packer/ansible/roles/android/files/android.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y android-sdk adb

--- a/packer/ansible/roles/android/meta/main.yml
+++ b/packer/ansible/roles/android/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: jenkins }

--- a/packer/ansible/roles/android/tasks/main.yml
+++ b/packer/ansible/roles/android/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: android.sh

--- a/packer/ansible/roles/ansible/files/ansible.sh
+++ b/packer/ansible/roles/ansible/files/ansible.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y ansible

--- a/packer/ansible/roles/ansible/meta/main.yml
+++ b/packer/ansible/roles/ansible/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: chrome }

--- a/packer/ansible/roles/ansible/tasks/main.yml
+++ b/packer/ansible/roles/ansible/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: ansible.sh

--- a/packer/ansible/roles/apache2/files/apache2.sh
+++ b/packer/ansible/roles/apache2/files/apache2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash --login
+sudo apt install -y apache2
+sudo a2enmod proxy
+sudo a2enmod proxy_http
+sudo a2enmod rewrite
+sudo a2enmod ssl
+sudo a2enmod headers
+# Disable Version Headers
+sudo /bin/bash --login -c 'echo -e "ServerSignature Off\nServerTokens Prod" >> /etc/apache2/apache2.conf'
+sudo /bin/bash --login -c "cp /csi/etc/apache2/*.conf /etc/apache2/sites-available/"

--- a/packer/ansible/roles/apache2/meta/main.yml
+++ b/packer/ansible/roles/apache2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: terminator }

--- a/packer/ansible/roles/apache2/tasks/main.yml
+++ b/packer/ansible/roles/apache2/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: apache2.sh

--- a/packer/ansible/roles/arachni/files/arachni.sh
+++ b/packer/ansible/roles/arachni/files/arachni.sh
@@ -1,0 +1,13 @@
+#!/bin/bash --login
+# TODO: Always grab latest release
+arachni_root='/opt/arachni'
+arachni_build_path="${arachni_root}/arachni-1.5.1-0.5.12"
+arachni_pkg='arachni-1.5.1-0.5.12-linux-x86_64.tar.gz'
+arachni_url="https://github.com/Arachni/arachni/releases/download/v1.5.1/${arachni_pkg}"
+
+sudo mkdir $arachni_root 
+sudo /bin/bash --login -c "cd ${arachni_root} && wget ${arachni_url} && tar -xzvf arachni-1.5.1-0.5.12-linux-x86_64.tar.gz && rm ${arachni_pkg}"
+
+ls $arachni_build_path/bin/* | while read arachni_bin; do 
+  sudo ln -sf $arachni_bin /usr/local/bin/
+done

--- a/packer/ansible/roles/arachni/meta/main.yml
+++ b/packer/ansible/roles/arachni/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: nmap_all_live_hosts }

--- a/packer/ansible/roles/arachni/tasks/main.yml
+++ b/packer/ansible/roles/arachni/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: arachni.sh

--- a/packer/ansible/roles/baresip/files/baresip.sh
+++ b/packer/ansible/roles/baresip/files/baresip.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y baresip

--- a/packer/ansible/roles/baresip/meta/main.yml
+++ b/packer/ansible/roles/baresip/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: sox }

--- a/packer/ansible/roles/baresip/tasks/main.yml
+++ b/packer/ansible/roles/baresip/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: baresip

--- a/packer/ansible/roles/bashrc/files/bashrc.sh
+++ b/packer/ansible/roles/bashrc/files/bashrc.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Initializes RVM for Normal Users
+sudo /bin/bash --login -c 'echo "source /etc/profile.d/rvm.sh" >> /etc/bash.bashrc'
+sudo /bin/bash --login -c 'echo "source /etc/profile.d/aliases.sh" >> /etc/bash.bashrc'

--- a/packer/ansible/roles/bashrc/meta/main.yml
+++ b/packer/ansible/roles/bashrc/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: rvm }

--- a/packer/ansible/roles/beef/files/beef.rb
+++ b/packer/ansible/roles/beef/files/beef.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Install BeEF from Source
+printf 'Installing BeEF ***********************************************************************'
+Dir.chdir('/opt')
+beef_root = '/opt/beef-dev/'
+`sudo git clone https://github.com/beefproject/beef.git beef-dev`
+beef_ruby_version = File.readlines("#{beef_root}/.ruby-version")[0].to_s.scrub.strip.chomp
+beef_gemset = File.readlines("#{beef_root}/.ruby-gemset")[0].to_s.scrub.strip.chomp
+`sudo bash --login -c "source /etc/profile.d/rvm.sh && rvm install ruby-#{beef_ruby_version} && rvm use ruby-#{beef_ruby_version} && rvm gemset create #{beef_gemset} && cd #{beef_root} && gem install bundler && bundle install"`

--- a/packer/ansible/roles/beef/meta/main.yml
+++ b/packer/ansible/roles/beef/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: csi }

--- a/packer/ansible/roles/beef/tasks/main.yml
+++ b/packer/ansible/roles/beef/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: beef.rb

--- a/packer/ansible/roles/burpsuite/files/burpsuite.sh
+++ b/packer/ansible/roles/burpsuite/files/burpsuite.sh
@@ -1,0 +1,11 @@
+#!/bin/bash --login
+
+printf "Installing Custom BurpBuddy API for Burpsuite *****************************************"
+sudo apt install -y openjdk-8-jdk maven
+burpbuddy_tp_root="/csi/third_party/burpbuddy"
+burp_root="/opt/burpsuite"
+burpbuddy_build_root="${burp_root}/burpbuddy/burp"
+sudo /bin/bash --login -c "mkdir ${burp_root} && cp -a ${burpbuddy_tp_root} ${burp_root} && cd ${burpbuddy_build_root} && mvn package && cp ${burpbuddy_build_root}/target/burpbuddy-2.3.1.jar ${burp_root}"
+
+# Config Free Version by Default...Burpsuite Pro Handled by Vagrant Provisioner & Userland Config
+sudo cp /usr/bin/burpsuite /opt/burpsuite/burpsuite-kali-native.jar

--- a/packer/ansible/roles/burpsuite/meta/main.yml
+++ b/packer/ansible/roles/burpsuite/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: beef }

--- a/packer/ansible/roles/burpsuite/tasks/main.yml
+++ b/packer/ansible/roles/burpsuite/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: burpsuite.sh

--- a/packer/ansible/roles/chrome/files/chrome.sh
+++ b/packer/ansible/roles/chrome/files/chrome.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y chromium chromium-driver

--- a/packer/ansible/roles/chrome/meta/main.yml
+++ b/packer/ansible/roles/chrome/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: geckodriver }

--- a/packer/ansible/roles/chrome/tasks/main.yml
+++ b/packer/ansible/roles/chrome/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: chrome.sh

--- a/packer/ansible/roles/csi/files/csi.sh
+++ b/packer/ansible/roles/csi/files/csi.sh
@@ -1,0 +1,60 @@
+#!/bin/bash --login
+os=$(uname -s)
+
+case $os in
+  "Darwin")
+    echo 'Installing wget to retrieve tesseract trained data...'
+    sudo port -N install wget
+
+    echo "Installing fontconfig..."
+    sudo port -N install fontconfig
+
+    echo 'Installing Postgres Libraries for pg gem...'
+    sudo port -N install postgresql96-server
+
+    echo 'Installing libpcap Libraries...'
+    sudo port -N install libpcap
+
+    echo "Installing libsndfile1 & libsndfile1-dev Libraries..."
+    sudo port -N install libsndfile
+
+    echo 'Installing ImageMagick...'
+    sudo port -N install imagemagick
+
+    echo 'Installing Tesseract OCR...'
+    sudo port -N install tesseract
+    sudo /bin/bash --login -c 'cd /opt/local/share/tessdata && wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata'
+    ;;
+  "Linux")
+    apt --version > /dev/null 2>&1
+    if [[ $? == 0 ]]; then
+      echo "Installing wget to retrieve tesseract trained data..."
+      sudo apt install -y wget
+
+      echo "Installing fontconfig..."
+      sudo apt install -y fontconfig
+
+      echo "Installing Postgres Libraries for pg gem..."
+      sudo apt install -y postgresql-server-dev-all
+
+      echo "Installing libpcap Libraries..."
+      sudo apt install -y libpcap-dev
+
+      echo "Installing libsndfile1 & libsndfile1-dev Libraries..."
+      sudo apt install -y libsndfile1 libsndfile1-dev
+
+      echo "Installing imagemagick & libmagickwand-dev Libraries..."
+      sudo apt install -y imagemagick libmagickwand-dev
+
+      echo "Installing tesseract-ocr-all & trainers..."
+      sudo /bin/bash --login -c 'apt install -y tesseract-ocr-all && cd /usr/share/tesseract-ocr && wget https://raw.githubusercontent.com/tesseract-ocr/tessdata/master/eng.traineddata'
+    else
+      echo "A Linux Distro was Detected, however, ${0} currently only supports Kali Rolling, Ubuntu, & OSX for now...feel free to install manually."
+    fi
+    ;;
+  *)
+    echo "${os} not currently supported."
+    exit 1
+esac
+
+sudo /bin/bash --login -c 'cd /csi && cp etc/metasploit/vagrant.yaml.EXAMPLE etc/metasploit/vagrant.yaml && sudo ./reinstall_csi_gemset.sh && ./build_csi_gem.sh && rubocop'

--- a/packer/ansible/roles/csi/meta/main.yml
+++ b/packer/ansible/roles/csi/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: ruby }

--- a/packer/ansible/roles/csi/tasks/main.yml
+++ b/packer/ansible/roles/csi/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: csi.sh

--- a/packer/ansible/roles/docker/files/docker.sh
+++ b/packer/ansible/roles/docker/files/docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash --login
+printf "Installing Dcoker ********************************************************************"
+docker_sources='/etc/apt/sources.list.d/docker.list'
+sudo /bin/bash --login -c "apt-get remove -y docker docker-engine docker.io*"
+sudo /bin/bash --login -c "apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common"
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+sudo bash --login -c "echo 'deb [arch=amd64] https://download.docker.com/linux/debian stretch stable' > ${docker_sources}"
+sudo apt update
+sudo apt install -y docker-ce docker-compose
+sudo usermod -aG docker vagrant
+sudo systemctl enable docker

--- a/packer/ansible/roles/docker/meta/main.yml
+++ b/packer/ansible/roles/docker/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: firefox }

--- a/packer/ansible/roles/docker/tasks/main.yml
+++ b/packer/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: docker.sh

--- a/packer/ansible/roles/docker_bashrc/files/docker_bashrc.sh
+++ b/packer/ansible/roles/docker_bashrc/files/docker_bashrc.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo 'source /etc/profile.d/rvm.sh' >> ~/.bashrc

--- a/packer/ansible/roles/docker_bashrc/tasks/main.yml
+++ b/packer/ansible/roles/docker_bashrc/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: docker_bashrc.sh

--- a/packer/ansible/roles/docker_rvm/files/docker_rvm.sh
+++ b/packer/ansible/roles/docker_rvm/files/docker_rvm.sh
@@ -1,0 +1,6 @@
+#!/bin/bash --login
+apt update && apt install -y sudo && apt install -y curl gnupg2
+curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
+
+# Multi-user install required due to the need to run MSFRPCD as root w/in metasploit gemset
+curl -sSL https://get.rvm.io | sudo bash -s latest

--- a/packer/ansible/roles/docker_rvm/tasks/main.yml
+++ b/packer/ansible/roles/docker_rvm/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: docker_rvm.sh

--- a/packer/ansible/roles/eyewitness/files/eyewitness.sh
+++ b/packer/ansible/roles/eyewitness/files/eyewitness.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y eyewitness

--- a/packer/ansible/roles/eyewitness/meta/main.yml
+++ b/packer/ansible/roles/eyewitness/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: arachni }

--- a/packer/ansible/roles/eyewitness/tasks/main.yml
+++ b/packer/ansible/roles/eyewitness/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: eyewitness.sh

--- a/packer/ansible/roles/firefox/files/firefox.sh
+++ b/packer/ansible/roles/firefox/files/firefox.sh
@@ -1,0 +1,8 @@
+#!/bin/bash --login
+# NOTE: As soon as firefox esr supports the headless flag, this provisioner can be removed.
+printf "Installing Firefox ********************************************************************"
+debian_unstable_sources='/etc/apt/sources.list.d/debian-unstable.list'
+sudo /bin/bash --login -c "echo 'deb http://ftp.debian.org/debian unstable main contrib non-free' > ${debian_unstable_sources}"
+sudo /bin/bash --login  -c "echo 'deb http://deb.debian.org/debian experimental main' >> ${debian_unstable_sources}"
+sudo apt update
+sudo apt install -y firefox

--- a/packer/ansible/roles/firefox/meta/main.yml
+++ b/packer/ansible/roles/firefox/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: vim }

--- a/packer/ansible/roles/firefox/tasks/main.yml
+++ b/packer/ansible/roles/firefox/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: firefox.sh

--- a/packer/ansible/roles/fuzzdb/files/fuzzdb.sh
+++ b/packer/ansible/roles/fuzzdb/files/fuzzdb.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo /bin/bash --login -c "cd /opt && git clone https://github.com/fuzzdb-project/fuzzdb.git fuzzdb-dev"

--- a/packer/ansible/roles/fuzzdb/meta/main.yml
+++ b/packer/ansible/roles/fuzzdb/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: openvpn }

--- a/packer/ansible/roles/fuzzdb/tasks/main.yml
+++ b/packer/ansible/roles/fuzzdb/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: fuzzdb.sh

--- a/packer/ansible/roles/geckodriver/files/geckodriver.sh
+++ b/packer/ansible/roles/geckodriver/files/geckodriver.sh
@@ -1,0 +1,3 @@
+#!/bin/bash --login
+firefox_plugin_path='/csi/third_party/geckodriver-v0.19.1-linux64.tar.gz'
+sudo tar -xzvf $firefox_plugin_path -C /usr/local/bin

--- a/packer/ansible/roles/geckodriver/meta/main.yml
+++ b/packer/ansible/roles/geckodriver/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: phantomjs_wrapper }

--- a/packer/ansible/roles/geckodriver/tasks/main.yml
+++ b/packer/ansible/roles/geckodriver/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: geckodriver.sh

--- a/packer/ansible/roles/install_vagrant_ssh_key/files/install_vagrant_ssh_key.sh
+++ b/packer/ansible/roles/install_vagrant_ssh_key/files/install_vagrant_ssh_key.sh
@@ -1,0 +1,8 @@
+#!/bin/bash --login
+mkdir -p /home/vagrant/.ssh
+chmod 0700 /home/vagrant/.ssh
+wget \
+  --no-check-certificate https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
+  -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/packer/ansible/roles/install_vagrant_ssh_key/tasks/main.yml
+++ b/packer/ansible/roles/install_vagrant_ssh_key/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: install_vagrant_ssh_key.sh

--- a/packer/ansible/roles/jenkins/files/jenkins.sh
+++ b/packer/ansible/roles/jenkins/files/jenkins.sh
@@ -1,0 +1,36 @@
+#!/bin/bash --login
+# Make sure the csi gemset has been loaded
+source /etc/profile.d/rvm.sh
+ruby_version=$(cat /csi/.ruby-version)
+rvm use ruby-$ruby_version@csi
+
+printf "Installing Jenkins ********************************************************************"
+domain_name=`hostname -d`
+wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | sudo apt-key add -
+# wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
+# sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
+sudo sh -c 'echo deb https://pkg.jenkins.io/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
+sudo apt update
+sudo apt install -y jenkins openjdk-8-jdk mongodb
+sudo /bin/bash --login -c "cp /csi/etc/jenkins/jenkins /etc/default/jenkins"
+sudo /bin/bash --login -c "sed -i \"s/DOMAIN/${domain_name}/g\" /etc/default/jenkins" 
+sudo usermod -a -G sudo jenkins
+sudo systemctl enable jenkins
+sudo systemctl restart jenkins
+
+printf "Sleeping 99s While Jenkins Daemon Wakes Up ********************************************"
+ruby -e "(0..99).each { print '.'; sleep 1 }"
+
+initial_admin_pwd=$(sudo cat /var/lib/jenkins/secrets/initialAdminPassword)
+
+# TODO: Get this working
+# printf "Updating Pre-Installed Jenkins Plugins ************************************************"
+# csi_jenkins_update_plugins --jenkins_ip 127.0.0.1 -U admin -P $initial_admin_pwd --no-restart-jenkins
+
+printf "Installing Necessary Jenkins Plugins **************************************************"
+csi_jenkins_install_plugin --jenkins_ip 127.0.0.1 \
+  -d 8888 \
+  -U admin \
+  -P $initial_admin_pwd \
+  --no-restart-jenkins \
+  -p "ace-editor, amazon-ecs, analysis-core, ansible, ansicolor, ant, antisamy-markup-formatter, aws-beanstalk-publisher-plugin, aws-credentials, aws-java-sdk, brakeman, branch-api, bugzilla, bulk-builder, cloudbees-folder, compress-artifacts, config-autorefresh-plugin, configurationslicing, confluence-publisher, credentials, credentials-binding, cvs, dashboard-view, dependency-check-jenkins-plugin, discard-old-build, disk-usage, dropdown-viewstabbar-plugin, durable-task, email-ext, envinject, environment-script, extended-choice-parameter, extended-read-permission, external-monitor-job, fortify360, git, git-client, git-server, gitbucket, github, github-api, github-branch-source, github-organization-folder, gitlab-hook, gitlab-plugin, handlebars, htmlpublisher, http_request, icon-shim, image-gallery, jackson2-api, javadoc, jenkins-jira-issue-updater, jira, job-import-plugin, jquery, jquery-detached, junit, ldap, log-parser, mailer, mapdb-api, matrix-auth, matrix-project, maven-plugin, metrics, metrics-diskusage, momentjs, mongodb-document-upload, nested-view, pam-auth, parameterized-trigger, pipeline-build-step, pipeline-input-step, pipeline-rest-api, pipeline-stage-step, pipeline-stage-view, plain-credentials, purge-build-queue-plugin, role-strategy, ruby-runtime, saml, scm-api, script-security, slack, ssh-agent, ssh-credentials, ssh-slaves, structs, subversion, text-finder, thinBackup, token-macro, translation, windows-slaves, workflow-aggregator, workflow-api, workflow-basic-steps, workflow-cps, workflow-cps-global-lib, workflow-durable-task-step, workflow-job, workflow-multibranch, workflow-scm-step, workflow-step-api, workflow-support, ws-cleanup"

--- a/packer/ansible/roles/jenkins/meta/main.yml
+++ b/packer/ansible/roles/jenkins/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: burpsuite }

--- a/packer/ansible/roles/jenkins/tasks/main.yml
+++ b/packer/ansible/roles/jenkins/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Execute Jenkins shell script
+- script: jenkins.sh

--- a/packer/ansible/roles/kali_customize/files/kali_customize.rb
+++ b/packer/ansible/roles/kali_customize/files/kali_customize.rb
@@ -1,0 +1,114 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# A list of these are available in /usr/share/applications/*.desktop
+panel_root = '/usr/share/applications'
+
+system("sudo chmod 777 #{panel_root}")
+
+File.open("#{panel_root}/csi-prototyper.desktop", 'w') do |f|
+  f.puts '[Desktop Entry]'
+  f.puts 'Name=csi'
+  f.puts 'Encoding=UTF-8'
+  f.puts 'Exec=/bin/bash --login -c "cd /csi && csi"'
+  f.puts 'Icon=gksu-root-terminal'
+  f.puts 'StartupNotify=false'
+  f.puts 'Terminal=true'
+  f.puts 'Type=Application'
+end
+
+File.open("#{panel_root}/csi-drivers.desktop", 'w') do |f|
+  f.puts '[Desktop Entry]'
+  f.puts 'Name=csi drivers'
+  f.puts 'Encoding=UTF-8'
+  f.puts 'Exec=/bin/bash --login -c "cd /csi && ls bin | grep -v csi_autoinc_version && /bin/bash"'
+  f.puts 'Icon=org.gnome.Software'
+  f.puts 'StartupNotify=false'
+  f.puts 'Terminal=true'
+  f.puts 'Type=Application'
+end
+
+File.open("#{panel_root}/csi-chromium-jenkins.desktop", 'w') do |f|
+  f.puts '[Desktop Entry]'
+  f.puts 'Name=Jenkins'
+  f.puts 'Encoding=UTF-8'
+  f.puts 'Exec=/bin/bash --login -c "/usr/bin/chromium https://jenkins.$(hostname -d)"'
+  f.puts 'Icon=dconf-editor'
+  f.puts 'Type=Application'
+  f.puts 'Categories=Network;WebBrowser;'
+  f.puts 'MimeType=text/html;text/xml;application/xhtml_xml;application/x-mimearchive;x-scheme-handler/http;x-scheme-handler/https;'
+  f.puts 'StartupWMClass=chromium'
+  f.puts 'StartupNotify=true'
+end
+
+File.open("#{panel_root}/csi-chromium-openvas.desktop", 'w') do |f|
+  f.puts '[Desktop Entry]'
+  f.puts 'Name=OpenVAS'
+  f.puts 'Encoding=UTF-8'
+  f.puts 'Exec=/bin/bash --login -c "/usr/bin/chromium https://openvas.$(hostname -d)"'
+  f.puts 'Terminal=false'
+  f.puts 'X-MultipleArgs=false'
+  f.puts 'Type=Application'
+  f.puts 'Icon=kali-OpenVas.png'
+  f.puts 'Categories=Network;WebBrowser;'
+  f.puts 'MimeType=text/html;text/xml;application/xhtml_xml;application/x-mimearchive;x-scheme-handler/http;x-scheme-handler/https;'
+  f.puts 'StartupWMClass=chromium'
+  f.puts 'StartupNotify=true'
+end
+
+File.open("#{panel_root}/csi-msfconsole.desktop", 'w') do |f|
+  f.puts '[Desktop Entry]'
+  f.puts 'Name=metasploit framework'
+  f.puts 'Encoding=UTF-8'
+  f.puts 'Exec=/bin/bash --login -c "cd /opt/metasploit-framework-dev && sudo msfconsole"'
+  f.puts 'Icon=kali-metasploit.png'
+  f.puts 'StartupNotify=false'
+  f.puts 'Terminal=true'
+  f.puts 'Type=Application'
+end
+
+File.open("#{panel_root}/csi-setoolkit.desktop", 'w') do |f|
+  f.puts '[Desktop Entry]'
+  f.puts 'Name=social engineering toolkit'
+  f.puts 'Encoding=UTF-8'
+  f.puts 'Exec=/bin/bash --login -c "sudo setoolkit"'
+  f.puts 'Icon=kali-set.png'
+  f.puts 'StartupNotify=false'
+  f.puts 'Terminal=true'
+  f.puts 'Type=Application'
+  f.puts 'Categories=08-exploitation-tools;13-social-engineering-tools;'
+  f.puts 'X-Kali-Package=set'
+end
+
+system("sudo chown root:root #{panel_root}/*.desktop")
+system("sudo chmod 755 #{panel_root}")
+
+panel_items = %(
+[
+  'gnome-control-center.desktop',
+  'csi-prototyper.desktop',
+  'csi-drivers.desktop',
+  'terminator.desktop',
+  'kali-recon-ng.desktop',
+  'csi-chromium-jenkins.desktop',
+  'csi-chromium-openvas.desktop',
+  'chromium.desktop',
+  'firefox-esr.desktop',
+  'kali-burpsuite.desktop',
+  'kali-zaproxy.desktop',
+  'csi-msfconsole.desktop',
+  'kali-searchsploit.desktop',
+  'csi-setoolkit.desktop',
+  'org.gnome.Nautilus.desktop'
+]
+)
+
+# Create the Custom Kali Panel
+system("dconf write /org/gnome/shell/favorite-apps \"#{panel_items}\"")
+
+# Use the CSI Wallpaper
+system('gsettings set org.gnome.desktop.background picture-uri file:///csi/documentation/virtualbox-gui_wallpaper.jpg')
+system('gsettings set org.gnome.desktop.background picture-options "centered"')
+
+# Always Show the Panel
+system('gsettings set org.gnome.shell.extensions.dash-to-dock dock-fixed true')

--- a/packer/ansible/roles/kali_customize/meta/main.yml
+++ b/packer/ansible/roles/kali_customize/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: vim }

--- a/packer/ansible/roles/kali_customize/tasks/main.yml
+++ b/packer/ansible/roles/kali_customize/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: kali_customize.rb

--- a/packer/ansible/roles/metasploit/files/metasploit.rb
+++ b/packer/ansible/roles/metasploit/files/metasploit.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+# Install Metasploit from Source
+printf 'Installing Metasploit *****************************************************************'
+metasploit_root = '/opt/metasploit-framework-dev'
+`sudo git clone https://github.com/rapid7/metasploit-framework.git #{metasploit_root}`
+`sudo apt install libpq-dev postgresql-server-dev-all`
+metasploit_ruby_version = File.readlines("#{metasploit_root}/.ruby-version")[0].to_s.scrub.strip.chomp
+metasploit_gemset = File.readlines("#{metasploit_root}/.ruby-gemset")[0].to_s.scrub.strip.chomp
+`sudo bash --login -c "source /etc/profile.d/rvm.sh && rvm install ruby-#{metasploit_ruby_version} && rvm use ruby-#{metasploit_ruby_version} && rvm gemset create #{metasploit_gemset} && cd #{metasploit_root} && gem install bundler && bundle install"`
+
+printf 'Starting up MSFRPCD *******************************************************************'
+system('sudo bash --login -c "cp /csi/etc/metasploit/vagrant.yaml.EXAMPLE /csi/etc/metasploit/vagrant.yaml"')
+system("sudo bash --login -c \"source /etc/profile.d/rvm.sh && rvm use ruby-#{metasploit_ruby_version}@#{metasploit_gemset} && cp /csi/etc/systemd/msfrpcd.service /etc/systemd/system/ && systemctl enable msfrpcd.service && systemctl start msfrpcd.service\"")

--- a/packer/ansible/roles/metasploit/meta/main.yml
+++ b/packer/ansible/roles/metasploit/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: openvas_wrappers }

--- a/packer/ansible/roles/metasploit/tasks/main.yml
+++ b/packer/ansible/roles/metasploit/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: metasploit.rb

--- a/packer/ansible/roles/nmap_all_live_hosts/files/nmap_all_live_hosts.sh
+++ b/packer/ansible/roles/nmap_all_live_hosts/files/nmap_all_live_hosts.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo /bin/bash --login -c 'cd /opt && git clone https://github.com/ninp0/nmap_all_live_hosts.git && ln -sf /opt/nmap_all_live_hosts/nmap_all_live_hosts.sh /usr/local/bin/'

--- a/packer/ansible/roles/nmap_all_live_hosts/meta/main.yml
+++ b/packer/ansible/roles/nmap_all_live_hosts/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: toggle_tor }

--- a/packer/ansible/roles/nmap_all_live_hosts/tasks/main.yml
+++ b/packer/ansible/roles/nmap_all_live_hosts/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: nmap_all_live_hosts.sh

--- a/packer/ansible/roles/openvas/files/openvas.sh
+++ b/packer/ansible/roles/openvas/files/openvas.sh
@@ -1,0 +1,15 @@
+#!/bin/bash --login
+sudo apt install -y rpm alien nsis openvas redis-server
+sudo systemctl enable redis-server
+sudo systemctl start redis-server
+sudo openvas-setup
+sudo openvas-check-setup
+# Add a working systemd daemon
+sudo cp /csi/etc/systemd/openvas.service /etc/systemd/system/
+# We leverage Virtual Hosting w/in Apache2 to provide TLS connection
+sudo sed -i '9s/.*/ExecStart=\/usr\/sbin\/gsad --foreground --listen=127\.0\.0\.1 --port=9392 --mlisten=127\.0\.0\.1 --mport=9390 --http-only --no-redirect/' /lib/systemd/system/greenbone-security-assistant.service
+sudo systemctl daemon-reload
+sudo systemctl enable openvas.service
+sudo systemctl start openvas.service
+# Symlink to folder containing NASL files
+sudo ln -s /var/lib/openvas/plugins /opt/openvas_plugins

--- a/packer/ansible/roles/openvas/meta/main.yml
+++ b/packer/ansible/roles/openvas/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: ansible }

--- a/packer/ansible/roles/openvas/tasks/main.yml
+++ b/packer/ansible/roles/openvas/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: openvas.sh

--- a/packer/ansible/roles/openvas_wrappers/files/openvas_wrappers.sh
+++ b/packer/ansible/roles/openvas_wrappers/files/openvas_wrappers.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo /bin/bash --login -c 'cd /opt && git clone https://github.com/ninp0/openvas_wrappers.git && ln -sf /opt/openvas_wrappers/continuous_openvas_scan_task.sh /usr/local/bin/ && ln -sf /opt/openvas_wrappers/continuous_openvas_scan_task_cert_authn.sh /usr/local/bin/'

--- a/packer/ansible/roles/openvas_wrappers/meta/main.yml
+++ b/packer/ansible/roles/openvas_wrappers/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: openvas }

--- a/packer/ansible/roles/openvas_wrappers/tasks/main.yml
+++ b/packer/ansible/roles/openvas_wrappers/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: openvas_wrappers.sh

--- a/packer/ansible/roles/openvpn/files/openvpn.sh
+++ b/packer/ansible/roles/openvpn/files/openvpn.sh
@@ -1,0 +1,4 @@
+#!/bin/bash --login
+sudo apt install -y openvpn resolvconf
+sudo systemctl enable resolvconf
+sudo systemctl start resolvconf

--- a/packer/ansible/roles/openvpn/meta/main.yml
+++ b/packer/ansible/roles/openvpn/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: strace }

--- a/packer/ansible/roles/openvpn/tasks/main.yml
+++ b/packer/ansible/roles/openvpn/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: openvpn.sh

--- a/packer/ansible/roles/peda/files/peda.sh
+++ b/packer/ansible/roles/peda/files/peda.sh
@@ -1,0 +1,4 @@
+#!/bin/bash --login
+# PEDA - Python Exploit Development Assistance for GDB to be used w/ AFL
+sudo /bin/bash --login -c 'cd /opt && git clone https://github.com/longld/peda.git peda-dev && echo "source /opt/peda-dev/peda.py" >> /root/.gdbinit'
+echo "source /opt/peda-dev/peda.py" >> /home/vagrant/.gdbinit

--- a/packer/ansible/roles/peda/meta/main.yml
+++ b/packer/ansible/roles/peda/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: afl }

--- a/packer/ansible/roles/peda/tasks/main.yml
+++ b/packer/ansible/roles/peda/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: peda.sh

--- a/packer/ansible/roles/phantomjs/files/phantomjs.rb
+++ b/packer/ansible/roles/phantomjs/files/phantomjs.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'rest-client'
+require 'nokogiri'
+
+printf 'Installing phantomjs ******************************************************************'
+phantomjs_tar_bz2 = ''
+phantomjs_tar_extraction_path = '/opt/phantomjs-releases'
+phantomjs_linux_download = ''
+url = 'http://phantomjs.org/download.html'
+# Look for specific links w/ pattern matching 64 bit linux tar.gz
+phantomjs_resp = RestClient.get(url)
+links = Nokogiri::HTML(phantomjs_resp).xpath('//a/@href')
+links.each do |link|
+  if link.value.match?(/linux-x86_64\.tar\.bz2/)
+    phantomjs_tar_bz2 = "/opt/#{File.basename(link.value)}"
+    phantomjs_linux_download = link.value
+  end
+end
+
+unless File.exist?(phantomjs_tar_bz2)
+  puts `sudo wget -O #{phantomjs_tar_bz2} #{phantomjs_linux_download}`
+end
+
+puts `sudo mkdir -p #{phantomjs_tar_extraction_path}` unless Dir.exist?(phantomjs_tar_extraction_path)
+puts `sudo tar -xjvf #{phantomjs_tar_bz2} -C #{phantomjs_tar_extraction_path}`
+phantomjs_tar_extracted_root = "#{phantomjs_tar_extraction_path}/#{File.basename(phantomjs_tar_bz2, '.tar.bz2')}"
+puts `sudo cp "#{phantomjs_tar_extracted_root}/bin/phantomjs" "/usr/local/bin/phantomjs"`
+puts `sudo rm #{phantomjs_tar_bz2}`

--- a/packer/ansible/roles/phantomjs/tasks/main.yml
+++ b/packer/ansible/roles/phantomjs/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: phantomjs.rb

--- a/packer/ansible/roles/phantomjs_wrapper/files/phantomjs_wrapper.sh
+++ b/packer/ansible/roles/phantomjs_wrapper/files/phantomjs_wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash --login
+source /etc/profile.d/rvm.sh
+ruby_version=$(cat /csi/.ruby-version)
+rvm use ruby-$ruby_version@csi
+
+# This is needed to ensure other ruby installations aren't picked up
+# by #!/usr/bin/env ruby inside of the script below
+/csi/packer/provisioners/phantomjs.rb

--- a/packer/ansible/roles/phantomjs_wrapper/meta/main.yml
+++ b/packer/ansible/roles/phantomjs_wrapper/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: baresip }

--- a/packer/ansible/roles/phantomjs_wrapper/tasks/main.yml
+++ b/packer/ansible/roles/phantomjs_wrapper/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: phantomjs_wrapper.sh

--- a/packer/ansible/roles/pwntools/files/pwntools.sh
+++ b/packer/ansible/roles/pwntools/files/pwntools.sh
@@ -1,0 +1,6 @@
+#!/bin/bash --login
+# Quick Prototyping of Exploits
+# $ ipython
+# in [1]: from pwn import *
+# More information available here: https://docs.pwntools.com/en/stable/
+sudo /bin/bash --login -c "apt update && apt install -y python2.7 python-pip python-dev git libssl-dev libffi-dev build-essential && pip install --upgrade pip && pip install --upgrade pwntools"

--- a/packer/ansible/roles/pwntools/meta/main.yml
+++ b/packer/ansible/roles/pwntools/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: peda }

--- a/packer/ansible/roles/pwntools/tasks/main.yml
+++ b/packer/ansible/roles/pwntools/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: pwntools.sh

--- a/packer/ansible/roles/rc.local/files/rc.local.sh
+++ b/packer/ansible/roles/rc.local/files/rc.local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash --login
+# Configure simple tasks to run @ boot
+
+sudo /bin/bash --login -c 'echo "#!/bin/sh -e" > /etc/rc.local'
+
+sudo /bin/bash --login -c 'echo "ifconfig lo:0 127.0.0.2 netmask 255.0.0.0 up" >> /etc/rc.local'
+sudo /bin/bash --login -c 'echo "ifconfig lo:1 127.0.0.3 netmask 255.0.0.0 up" >> /etc/rc.local'
+sudo /bin/bash --login -c 'echo "ifconfig lo:2 127.0.0.4 netmask 255.0.0.0 up" >> /etc/rc.local'
+sudo /bin/bash --login -c 'echo "sudo -H -u vagrant /usr/local/bin/toggle_tor.sh" >> /etc/rc.local'
+
+sudo /bin/bash --login -c 'echo "exit 0" >> /etc/rc.local'
+sudo /bin/bash --login -c 'chmod 755 /etc/rc.local'

--- a/packer/ansible/roles/rc.local/meta/main.yml
+++ b/packer/ansible/roles/rc.local/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: fuzzdb }

--- a/packer/ansible/roles/rc.local/tasks/main.yml
+++ b/packer/ansible/roles/rc.local/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: rc.local.sh

--- a/packer/ansible/roles/reboot_os/files/reboot_os.sh
+++ b/packer/ansible/roles/reboot_os/files/reboot_os.sh
@@ -1,0 +1,7 @@
+#!/bin/bash --login
+# nohup prevents freezes in Packer due to execution moving to the next
+# script while a reboot is in progress. This should be coupled with a
+# "pause_before" stanza for the next provisioner in the Packer
+# to guarantee the required behaviour.
+nohup sudo shutdown --reboot now </dev/null >/dev/null 2>&1 &
+exit 0

--- a/packer/ansible/roles/reboot_os/tasks/main.yml
+++ b/packer/ansible/roles/reboot_os/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: reboot_os.sh

--- a/packer/ansible/roles/ruby/files/ruby.sh
+++ b/packer/ansible/roles/ruby/files/ruby.sh
@@ -1,0 +1,23 @@
+#!/bin/bash --login
+os=$(uname -s)
+
+case $os in
+  'Darwin')
+    sudo port -N install bison openssl curl git zlib libyaml libxml2 autoconf ncurses automake libtool libpcap
+    ;;
+  'Linux')
+    sudo apt install -y build-essential bison openssl libreadline-dev curl git-core git zlib1g zlib1g-dev libssl-dev libyaml-dev libxml2-dev autoconf libc6-dev ncurses-dev automake libtool libpcap-dev libsqlite3-dev libgmp-dev
+    ;;
+  *)
+    echo "${os} not currently supported."
+    exit 1
+esac
+
+
+# We clone CSI here instead of csi.sh so ruby knows what version of ruby to install
+# per the latest value of .ruby-version in the repo.
+sudo /bin/bash --login -c 'cd / && git clone https://github.com/ninp0/csi.git'
+
+ruby_version=$(cat /csi/.ruby-version)
+ruby_gemset=$(cat /csi/.ruby-gemset)
+sudo /bin/bash --login -c "source /etc/profile.d/rvm.sh && rvm install ruby-${ruby_version}"

--- a/packer/ansible/roles/ruby/meta/main.yml
+++ b/packer/ansible/roles/ruby/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: bashrc }

--- a/packer/ansible/roles/ruby/tasks/main.yml
+++ b/packer/ansible/roles/ruby/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: ruby.sh

--- a/packer/ansible/roles/rvm/files/rvm.sh
+++ b/packer/ansible/roles/rvm/files/rvm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash --login
+os=$(uname -s)
+
+case $os in
+  'Darwin')
+    sudo port -N install gnupg2
+    ;;
+  'Linux')
+    sudo apt install -y gnupg2
+    ;;
+  *)
+    echo "${os} not currently supported."
+    exit 1
+esac
+
+curl -sSL https://rvm.io/mpapis.asc | sudo gpg2 --import -
+sudo /bin/bash --login -c 'echo -e "trust\n5\ny\n" | gpg2 --command-fd 0 --edit-key 409B6B1796C275462A1703113804BB82D39DC0E3'
+
+# Multi-user install required due to the need to run MSFRPCD as root w/in metasploit gemset
+curl -sSL https://get.rvm.io | sudo bash -s latest

--- a/packer/ansible/roles/rvm/meta/main.yml
+++ b/packer/ansible/roles/rvm/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: aliases }

--- a/packer/ansible/roles/rvm/tasks/main.yml
+++ b/packer/ansible/roles/rvm/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: rvm.sh

--- a/packer/ansible/roles/scapy/files/scapy.sh
+++ b/packer/ansible/roles/scapy/files/scapy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo apt install -y python-scapy

--- a/packer/ansible/roles/scapy/meta/main.yml
+++ b/packer/ansible/roles/scapy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: sublist3r }

--- a/packer/ansible/roles/scapy/tasks/main.yml
+++ b/packer/ansible/roles/scapy/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: scapy.sh

--- a/packer/ansible/roles/scout2/files/scout2.sh
+++ b/packer/ansible/roles/scout2/files/scout2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash --login
+# Security Auditing tool for AWS Environments
+# $ Scout2 -h
+# More information available here: https://github.com/nccgroup/Scout2
+sudo -H pip install awsscout2

--- a/packer/ansible/roles/scout2/meta/main.yml
+++ b/packer/ansible/roles/scout2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: pwntools }

--- a/packer/ansible/roles/scout2/tasks/main.yml
+++ b/packer/ansible/roles/scout2/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: scout2.sh

--- a/packer/ansible/roles/sox/files/sox.sh
+++ b/packer/ansible/roles/sox/files/sox.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y sox

--- a/packer/ansible/roles/sox/meta/main.yml
+++ b/packer/ansible/roles/sox/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: android }

--- a/packer/ansible/roles/ssllabs-scan/files/ssllabs-scan.sh
+++ b/packer/ansible/roles/ssllabs-scan/files/ssllabs-scan.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+ssllabs_root="/opt/ssllabs-scan"
+sudo apt install -y golang
+sudo /bin/bash --login -c "cd /opt && git clone https://github.com/ssllabs/ssllabs-scan.git"
+sudo /bin/bash --login -c "cd ${ssllabs_root} && make && ln -sf ${ssllabs_root}/ssllabs-scan /usr/local/bin/"

--- a/packer/ansible/roles/ssllabs-scan/meta/main.yml
+++ b/packer/ansible/roles/ssllabs-scan/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: wpscan }

--- a/packer/ansible/roles/ssllabs-scan/tasks/main.yml
+++ b/packer/ansible/roles/ssllabs-scan/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: ssllabs-scan.sh

--- a/packer/ansible/roles/strace/files/strace.sh
+++ b/packer/ansible/roles/strace/files/strace.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y strace

--- a/packer/ansible/roles/strace/meta/main.yml
+++ b/packer/ansible/roles/strace/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: scout2 }

--- a/packer/ansible/roles/strace/tasks/main.yml
+++ b/packer/ansible/roles/strace/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: strace

--- a/packer/ansible/roles/sublist3r/files/sublist3r.sh
+++ b/packer/ansible/roles/sublist3r/files/sublist3r.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo /bin/bash --login -c 'cd /opt && git clone https://github.com/aboul3la/Sublist3r.git && ln -sf /opt/Sublist3r/sublist3r.py /usr/local/bin/'

--- a/packer/ansible/roles/sublist3r/meta/main.yml
+++ b/packer/ansible/roles/sublist3r/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: ssllabs-scan }

--- a/packer/ansible/roles/sublist3r/tasks/main.yml
+++ b/packer/ansible/roles/sublist3r/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: sublist3r.sh

--- a/packer/ansible/roles/terminator/files/terminator.sh
+++ b/packer/ansible/roles/terminator/files/terminator.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y terminator

--- a/packer/ansible/roles/terminator/meta/main.yml
+++ b/packer/ansible/roles/terminator/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: scapy }

--- a/packer/ansible/roles/terminator/tasks/main.yml
+++ b/packer/ansible/roles/terminator/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: terminator.sh

--- a/packer/ansible/roles/toggle_tor/files/toggle_tor.sh
+++ b/packer/ansible/roles/toggle_tor/files/toggle_tor.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo /bin/bash --login -c 'cd /opt && git clone https://github.com/ninp0/toggle_tor.git && ln -sf /opt/toggle_tor/toggle_tor.sh /usr/local/bin/'

--- a/packer/ansible/roles/toggle_tor/meta/main.yml
+++ b/packer/ansible/roles/toggle_tor/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: tor }

--- a/packer/ansible/roles/toggle_tor/tasks/main.yml
+++ b/packer/ansible/roles/toggle_tor/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: toggle_tor.sh

--- a/packer/ansible/roles/tor/files/tor.sh
+++ b/packer/ansible/roles/tor/files/tor.sh
@@ -1,0 +1,2 @@
+#!/bin/bash --login
+sudo apt install -y tor tor-geoipdb torsocks

--- a/packer/ansible/roles/tor/meta/main.yml
+++ b/packer/ansible/roles/tor/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: apache2 }

--- a/packer/ansible/roles/tor/tasks/main.yml
+++ b/packer/ansible/roles/tor/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: tor.sh

--- a/packer/ansible/roles/update_os/files/reboot_os.sh
+++ b/packer/ansible/roles/update_os/files/reboot_os.sh
@@ -1,0 +1,7 @@
+#!/bin/bash --login
+# nohup prevents freezes in Packer due to execution moving to the next
+# script while a reboot is in progress. This should be coupled with a
+# "pause_before" stanza for the next provisioner in the Packer
+# to guarantee the required behaviour.
+nohup sudo shutdown --reboot now </dev/null >/dev/null 2>&1 &
+exit 0

--- a/packer/ansible/roles/update_os/files/update_os.sh
+++ b/packer/ansible/roles/update_os/files/update_os.sh
@@ -1,0 +1,12 @@
+#!/bin/bash --login
+# Get Latest Updates
+sudo apt update
+
+# Install Dependency to Automate Package Install Questions
+sudo apt install -y debconf-utils
+
+# Automate Package Install Questions :)
+# Obtain values via: debconf-get-selections | less
+sudo /bin/bash --login -c "echo 'libc6 libraries/restart-without-asking boolean true' | debconf-set-selections && echo 'console-setup console-setup/codeset47 select Guess optimal character set' | debconf-set-selections && echo 'grub-pc grub-pc/install_devices multiselect /dev/sda1' | debconf-set-selections && echo 'wireshark-common wireshark-common/install-setuid boolean false' | debconf-set-selections && apt -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' dist-upgrade -y && apt -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade -y && apt autoremove -y && apt -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install -y apt-file && apt-file update"
+
+sudo apt install -y kali-linux-all

--- a/packer/ansible/roles/update_os/tasks/main.yml
+++ b/packer/ansible/roles/update_os/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+# Execute an OS upgrade
+- script: update_os.sh
+- script: reboot_os.sh

--- a/packer/ansible/roles/vim/files/vim.sh
+++ b/packer/ansible/roles/vim/files/vim.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Disable auto-indent
+sudo sed -i 's/  filetype plugin indent on/  filetype plugin indent off/g' /usr/share/vim/vim80/defaults.vim
+
+# Disable visual mode when highlighting text with mouse
+sudo sed -i 's/  set mouse=a/  set mouse-=a/g' /usr/share/vim/vim80/defaults.vim

--- a/packer/ansible/roles/vim/meta/main.yml
+++ b/packer/ansible/roles/vim/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: rc.local }

--- a/packer/ansible/roles/vim/tasks/main.yml
+++ b/packer/ansible/roles/vim/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: vim.sh

--- a/packer/ansible/roles/virtualbox_guest_additions/files/reboot_os.sh
+++ b/packer/ansible/roles/virtualbox_guest_additions/files/reboot_os.sh
@@ -1,0 +1,7 @@
+#!/bin/bash --login
+# nohup prevents freezes in Packer due to execution moving to the next
+# script while a reboot is in progress. This should be coupled with a
+# "pause_before" stanza for the next provisioner in the Packer
+# to guarantee the required behaviour.
+nohup sudo shutdown --reboot now </dev/null >/dev/null 2>&1 &
+exit 0

--- a/packer/ansible/roles/virtualbox_guest_additions/files/virtualbox_guest_additions.sh
+++ b/packer/ansible/roles/virtualbox_guest_additions/files/virtualbox_guest_additions.sh
@@ -1,0 +1,4 @@
+#!/bin/bash --login
+sudo apt purge -y virtualbox-*
+sudo apt install -y linux-headers-$(uname -r)
+sudo apt install -y virtualbox-guest-x11

--- a/packer/ansible/roles/virtualbox_guest_additions/meta/main.yml
+++ b/packer/ansible/roles/virtualbox_guest_additions/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: wait_for_reboot }

--- a/packer/ansible/roles/virtualbox_guest_additions/tasks/main.yml
+++ b/packer/ansible/roles/virtualbox_guest_additions/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- script: virtualbox_guest_additions.sh
+- script: reboot_os.sh

--- a/packer/ansible/roles/vmware_tools/files/vmware_tools.sh
+++ b/packer/ansible/roles/vmware_tools/files/vmware_tools.sh
@@ -1,0 +1,3 @@
+#!/bin/bash --login
+sudo apt install -y linux-headers-$(uname -r)
+sudo apt install --reinstall -y open-vm-tools-desktop fuse

--- a/packer/ansible/roles/vmware_tools/tasks/main.yml
+++ b/packer/ansible/roles/vmware_tools/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: vmware_tools.sh

--- a/packer/ansible/roles/wait_for_reboot/tasks/main.yml
+++ b/packer/ansible/roles/wait_for_reboot/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: wait for reboot
+  local_action: wait_for_host={{ ansible_ssh_host | default(inventory_hostname) }} state=started timeout=300 

--- a/packer/ansible/roles/wpscan/files/wpscan.rb
+++ b/packer/ansible/roles/wpscan/files/wpscan.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+Dir.chdir('/opt')
+wpscan_root = '/opt/wpscan-dev/'
+`sudo git clone https://github.com/wpscanteam/wpscan.git wpscan-dev`
+wpscan_ruby_version = File.readlines("#{wpscan_root}/.ruby-version")[0].to_s.scrub.strip.chomp
+wpscan_gemset = File.readlines("#{wpscan_root}/.ruby-gemset")[0].to_s.scrub.strip.chomp
+`sudo bash --login -c "apt install -y libcurl4-gnutls-dev && source /etc/profile.d/rvm.sh && rvm install ruby-#{wpscan_ruby_version} && rvm use ruby-#{wpscan_ruby_version} && rvm gemset create #{wpscan_gemset} && rvm use ruby-#{wpscan_ruby_version}@#{wpscan_gemset} && cd #{wpscan_root} && gem install bundler && bundle install --without test"`

--- a/packer/ansible/roles/wpscan/meta/main.yml
+++ b/packer/ansible/roles/wpscan/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: metasploit }

--- a/packer/ansible/roles/wpscan/tasks/main.yml
+++ b/packer/ansible/roles/wpscan/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- script: wpscan.rb


### PR DESCRIPTION
playbook.yaml uses script tasks and points to .sh and .rb scripts in various role directories
The playbook may be converted to use ansible roles (http://docs.ansible.com/ansible/latest/playbooks_reuse_roles.html) at a later date
A packer template which makes use of the ansible provisioner must define "staging_directory" and provide a path that is referenced by playbook.yaml for the script locations.
